### PR TITLE
Parse should return entire file when parse fails

### DIFF
--- a/lib/build/parse.js
+++ b/lib/build/parse.js
@@ -29,13 +29,19 @@ module.exports = function (text) {
 		}
 	};
 
+	var hasSteal = false;
 	parsed.body.forEach(function (statement) {
 		var expr = statement.expression;
 		// Looks for the first steal(..., function() {})
 		if (statement.type === 'ExpressionStatement' && expr.callee && expr.callee.name === 'steal') {
 			expr.arguments.forEach(processSteal);
+			hasSteal = true;
 		}
 	});
+
+	if(!hasSteal) {
+		return text;
+	}
 
 	return fn.join('\n');
 }

--- a/test/fixture/nonsteal.js
+++ b/test/fixture/nonsteal.js
@@ -1,0 +1,57 @@
+define([
+        "../core",
+        "./var/rnumnonpx",
+        "./var/rmargin",
+        "./var/getStyles",
+        "../selector" // contains
+], function( jQuery, rnumnonpx, rmargin, getStyles ) {
+
+function curCSS( elem, name, computed ) {
+        var width, minWidth, maxWidth, ret,
+                style = elem.style;
+
+        computed = computed || getStyles( elem );
+
+        // Support: IE9
+        // getPropertyValue is only needed for .css('filter') in IE9, see #12537
+        if ( computed ) {
+                ret = computed.getPropertyValue( name ) || computed[ name ];
+        }
+
+        if ( computed ) {
+
+                if ( ret === "" && !jQuery.contains( elem.ownerDocument, elem ) ) {
+                        ret = jQuery.style( elem, name );
+                }
+
+                // Support: iOS < 6
+                // A tribute to the "awesome hack by Dean Edwards"
+                // iOS < 6 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
+                // this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
+                if ( rnumnonpx.test( ret ) && rmargin.test( name ) ) {
+
+                        // Remember the original values
+                        width = style.width;
+                        minWidth = style.minWidth;
+                        maxWidth = style.maxWidth;
+
+                        // Put in the new values to get a computed value out
+                        style.minWidth = style.maxWidth = style.width = ret;
+                        ret = computed.width;
+
+                        // Revert the changed values
+                        style.width = width;
+                        style.minWidth = minWidth;
+                        style.maxWidth = maxWidth;
+                }
+        }
+
+        return ret !== undefined ?
+                // Support: IE
+                // IE returns zIndex value as an integer.
+                ret + "" :
+                ret;
+}
+
+return curCSS;
+});

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var fs = require('fs');
 var parse = require('../lib/build/parse');
 
 describe('Steal function parsing', function(){
@@ -18,5 +19,13 @@ describe('Steal function parsing', function(){
 			"return content + test + other; }"
 
 		assert.equal(parse(text), expected);
+	});
+
+	it('Returns entire text when steal does not exist', function() {
+		fs.readFile('test/fixture/nonsteal.js', function(error, data) {
+			var text = data.toString();
+
+			assert.equal(parse(text), text);
+		});
 	});
 });


### PR DESCRIPTION
Currently parse returns an empty array if "steal" isn't found within the file text. In this case the entire file contents should just be returned.
