### PR TITLE
Adding devmode option and customizable -remove tags.

### DIFF
--- a/lib/build/amdify.js
+++ b/lib/build/amdify.js
@@ -73,10 +73,12 @@ _.extend(amdify, {
 				// The last dependency is the module itself, we don't need that
 				dependencies.pop();
 
-				results[amdify.convertName(stl, options.map)] = _.template(options.wrapper, {
+				var content = opener.clean(_.template(options.wrapper, {
 					parsed: stl.options.parsed,
 					dependencies: dependencies
-				});
+				}), options);
+
+				results[amdify.convertName(stl, options.map)] = content;
 			}
 		});
 

--- a/lib/build/open.js
+++ b/lib/build/open.js
@@ -5,11 +5,6 @@ var _ = require('underscore');
 var ignores = ['steal/dev/dev.js', 'stealconfig.js'];
 var vm = require('vm');
 var parse = require('./parse');
-var parseContent = function(text) {
-	return parse(text)
-		.replace(/(\s?)\/\/!steal-remove-start((.|\n)*?)\/\/!steal-remove-end/gim, '')
-		.replace(/(\s?)\/\/!pluginify-remove-start((.|\n)*?)\/\/!pluginify-remove-end/gim, '');
-}
 
 /**
  * Opens one or more files by id, loads all depenencies and returns
@@ -50,7 +45,7 @@ function opener(id, options, cb) {
 						vm.runInContext(text, context);
 						// Also store a version of the parsed out function body with all `steal-remove`
 						// and `pluginify-remove` blocks stripped out
-						options.parsed = parseContent(text);
+						options.parsed =  parse(text);
 					}
 					options.text = text;
 					success();
@@ -110,6 +105,21 @@ opener.visit = function visit(steals, callback, visited) {
 		}
 	});
 	return visited;
+}
+
+opener.clean = function(original, options) {
+	var result = original;
+	var removeTags = options.removeTags || ['steal-remove'];
+
+	if(!options.dev) {
+		removeTags.push('dev-remove');
+	}
+
+	_.each(removeTags, function(tag) {
+		result = result.replace(new RegExp('(\\s?)\/\/!' + tag + '-start((.|\n)*?)\/\/!' + tag + '-end', 'gim'), '');
+	});
+
+	return result;
 }
 
 module.exports = opener;

--- a/lib/build/pluginify.js
+++ b/lib/build/pluginify.js
@@ -118,8 +118,10 @@ _.extend(pluginify, {
 			});
 		}
 
+		var content = opener.clean(contents.join('\n'), options);
+
 		callback(null, _.template(options.wrapper, {
-			content: contents.join('\n'),
+			content: content,
 			exports: exportModules
 		}));
 	}

--- a/test/fixture/hello/world.js
+++ b/test/fixture/hello/world.js
@@ -4,6 +4,9 @@ steal(function() {
 	//!steal-remove-start
 	world = "Steal";
 	//!steal-remove-end
+//!dev-remove-start
+	world = "Dev";
+//!dev-remove-end
 
 	return world;
 });

--- a/test/pluginify.js
+++ b/test/pluginify.js
@@ -61,6 +61,34 @@ describe('Pluginify', function() {
 		});
 	});
 
+	it('Pluginifies the hello fixture with dev statements left in', function(done) {
+		var exporter = {};
+
+		// Run pluginify on hello/hello.js in the current folder.
+		// Export it to pluginifyMessage
+		// Set the wrapper so that it will be added to the exporter object
+		pluginify('hello', {
+			dev: true,
+			steal: {
+				root: __dirname + '/fixture/'
+			},
+			exports: {
+				'hello': 'pluginifyMessage',
+				'hello/world.js': 'world'
+			},
+			wrapper: '!function(window, undefined) {\n<%= content %>\n\n' +
+				'<%= exports.join("\\n") %>\n' +
+				'}(exporter);'
+		}, function(error, content) {
+			// Run the pluginified content
+			eval(content);
+			// And make sure that the exported object got updated
+			assert.equal(exporter.pluginifyMessage, 'Hello Dev DEV!');
+			assert.equal(exporter.world, 'Dev');
+			done();
+		});
+	});
+
 	it('pluginify.ignores', function() {
 		var ignores = [ 'bla/x.js', 'foo/', /\/lib\//];
 		assert.ok(pluginify.ignores('ma/lib/foo.js', ignores));

--- a/test/steal.js
+++ b/test/steal.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 describe('Steal', function(){
 	it('Steals files and loads modules', function(done) {
 		steal('test/fixture/hello', function(message) {
-			assert.equal(message, 'Hello Steal STEAL!');
+			assert.equal(message, 'Hello Dev DEV!');
 			done();
 		});
 	});


### PR DESCRIPTION
This pull request adds the ability to add customizable `-start` and `-end` blocks that will be removed in the build, e.g.

``` js
//!steal-remove-start
Stuff that will be removed in a Steal build
//!steal-remove-end
```
