### PR TITLE
Allow pluginifying of shimmed values.

### DIFF
--- a/lib/build/amdify.js
+++ b/lib/build/amdify.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 var opener = require('./open');
 
 /**

--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 var async = require('async');
 var path = require('path');
 var fs = require('fs');

--- a/lib/build/open.js
+++ b/lib/build/open.js
@@ -1,7 +1,7 @@
 var steal = require('../steal');
 var fs = require('fs');
 var path = require('path');
-var _ = require('underscore');
+var _ = require('lodash');
 var ignores = ['steal/dev/dev.js', 'stealconfig.js'];
 var vm = require('vm');
 var parse = require('./parse');

--- a/lib/build/pluginify.js
+++ b/lib/build/pluginify.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 var parse = require('./parse');
 var opener = require('./open');
 
@@ -9,11 +9,12 @@ var opener = require('./open');
  * @param callback
  */
 function pluginify(ids, options, callback) {
+	var opts = _.cloneDeep(options);
 	opener(ids, options.steal || {}, function (error, rootSteals, opener) {
 		// Call pluginifySteals and extend the options with the opener Steal
 		pluginify.pluginifySteals(rootSteals, _.extend({
 			opener: opener
-		}, options), callback);
+		}, opts), callback);
 	});
 }
 
@@ -24,7 +25,11 @@ _.extend(pluginify, {
 			'})();\n',
 		exportsTemplate: 'window[\'<%= name %>\'] = <%= module %>;',
 		moduleTemplate: '\n// ## <%= moduleName %>\nvar <%= variableName %> = ' +
-			'(<%= parsed %>)(<%= dependencies.join(", ") %>);'
+			'<% if(shim.exports) { %>' +
+				'(function() {\n<%= text %>\nreturn <%= shim.exports %>;\n})();\n' +
+			'<% } else { %>' +
+				'(<%= parsed %>)(<%= dependencies.join(", ") %>);' +
+			'<% } %>'
 	},
 
 	/**
@@ -64,10 +69,16 @@ _.extend(pluginify, {
 
 		// Stores mappings from module ids to pluginified variable names
 		var nameMap = {};
+		// Store steal shims (e.g. jQuery)
+		var stealShims = {};
 		var contents = [];
 
 		_.each(options.shim, function(variable, id) {
 			nameMap[options.opener.id(id)] = variable;
+		});
+
+		_.each(options.steal && options.steal.shim, function(shim, name) {
+			stealShims[options.opener.id(name)] = shim;
 		});
 
 		// Go through all dependencies
@@ -89,21 +100,15 @@ _.extend(pluginify, {
 				// The last dependency is the module itself, we don't need that
 				dependencies.pop();
 
-				var part;
-				//if parsed is undefined && text is populated, we're dealing with a
-				//file that had no steal, but ran through pluginify.
-				if(!stl.options.parsed && stl.options.text) {
-					part = '\t!function() {\n\t\t' + stl.options.text + '\n\t}();';
-				}
-				else {
-					// Render the template for this module
-					part = _.template(options.moduleTemplate, {
-						moduleName: id,
-						variableName: variableName,
-						parsed: stl.options.parsed,
-						dependencies: dependencies
-					});
-				}
+				// Render the template for this module
+				var part = _.template(options.moduleTemplate, {
+					moduleName: id,
+					variableName: variableName,
+					parsed: stl.options.parsed,
+					text: stl.options.text,
+					dependencies: dependencies,
+					shim: stealShims['' + stl.options.id] || {}
+				});
 
 				contents.push(part);
 			}

--- a/lib/build/stealify.js
+++ b/lib/build/stealify.js
@@ -1,4 +1,4 @@
-var _ = require('underscore');
+var _ = require('lodash');
 var opener = require('./open');
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test": "mocha test"
   },
   "dependencies": {
-    "underscore": "~ 1.4.0",
     "esprima": "~ 1.0.0",
     "js-beautify": "~1.3.2",
-    "async": "~0.2.8"
+    "async": "~0.2.8",
+    "lodash": "~2.4.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",

--- a/test/builder.js
+++ b/test/builder.js
@@ -1,6 +1,6 @@
 var builder = require('../lib/build/builder');
 var assert = require('assert');
-var _ = require('underscore');
+var _ = require('lodash');
 
 describe('Steal download builder tests', function() {
 	it('builder.banner', function() {

--- a/test/fixture/nonsteal-expected.js
+++ b/test/fixture/nonsteal-expected.js
@@ -1,0 +1,13 @@
+(function(undefined) {
+
+// ## nonsteal.js
+var __m1 = (function() {
+!function(window) {
+	window.test = 'Hi';
+}(window);
+return test;
+})();
+
+
+
+})();

--- a/test/fixture/nonsteal-shim.js
+++ b/test/fixture/nonsteal-shim.js
@@ -1,5 +1,0 @@
-!function(window) {
-	!function() {
-		(function() {})()
-	}();
-}(window);

--- a/test/fixture/nonsteal.js
+++ b/test/fixture/nonsteal.js
@@ -1,1 +1,3 @@
-(function() {})()
+!function(window) {
+	window.test = 'Hi';
+}(window);

--- a/test/pluginify.js
+++ b/test/pluginify.js
@@ -100,32 +100,19 @@ describe('Pluginify', function() {
 		assert.ok(!pluginify.ignores('my/foo/bar.js', ignores));
 	});
 
-	it('Pluginifies the a nonsteal fixture', function(done) {
+	it('Pluginifies a shimmed nonsteal file', function(done) {
 		pluginify('nonsteal.js', {
 			steal: {
-				root: __dirname + '/fixture/'
-			},
-			wrapper: '!function(window) {\n<%= content %>\n}(window);'
+				root: __dirname + '/fixture/',
+				shim: {
+					'nonsteal.js': {
+						exports: 'test'
+					}
+				}
+			}
 		}, function(error, content) {
-			fs.readFile('test/fixture/nonsteal-shim.js', function(err, data) {
+			fs.readFile('test/fixture/nonsteal-expected.js', function(err, data) {
 				var text = data.toString();
-
-				assert.equal(content, text);
-				done();
-			});
-		});
-	});
-
-	it('Pluginified shims', function(done) {
-		pluginify('nonsteal.js', {
-			steal: {
-				root: __dirname + '/fixture/'
-			},
-			wrapper: '!function(window) {\n<%= content %>\n}(window);'
-		}, function(error, content) {
-			fs.readFile('test/fixture/nonsteal-shim.js', function(err, data) {
-				var text = data.toString();
-
 				assert.equal(content, text);
 				done();
 			});


### PR DESCRIPTION
This pull request allows to pluginify shimmed values like an actual modules which e.g. allows things like including jQuery and putting it into no conflict mode (needed for FuncUnit). Also switches from Underscore to Lodash (mainly because we needed `_.deepClone`).
