### PR TITLE
Remove plugin option from pluginify

### DIFF
--- a/lib/build/builder.js
+++ b/lib/build/builder.js
@@ -245,71 +245,34 @@ var utilities = {
 				return item.isDefault;
 			});
 
-		if (options.plugin) {
+		ids = utilities.getIds(options.ids, info.modules);
 
-			plugin = options.plugin;
-			pluginConfigurations = info.modules[plugin].configurations;
-			ids = plugin;
+		if (!configuration) {
+			return callback(new Error('No configuration for: ' + options.configuration));
+		}
 
-			opener(plugin, info.stealConfig, function (error, steals, opener) {
+		// From the list of ids get all our Steals
+		buildSteals = utilities.getSteals(configuration.steals, ids);
+		pluginifyOptions = _.extend({
+			opener: configuration.steals.opener,
+			dev: options.dev
+		}, options.pluginify, info.pluginify, configuration.pluginify);
 
-				var params = "";
-
-				if (pluginConfigurations) {
-					pluginConfigurations.forEach(function (configDependency) {
-						var dep = utilities.getConfigParams(configDependency);
-						if(dep) {
-							params += dep + ",";
-						}
-					});
-				}
-
-				params += "can";
-
-				var content = '(' + steals[0].options.parsed + ')(' + params + ');';
-
-				var banner = info.banner ? utilities.banner(info.banner, {
-					url: options.url || '',
-					info: info,
-					pkg: info,
-					ids: ids
-				}) : '';
-
-				content = stealOpener.clean(utilities.prettify(content, info.beautify), options);
-
-				callback(null, content, banner);
-			});
-
-		} else {
-			ids = utilities.getIds(options.ids, info.modules);
-
-			if (!configuration) {
-				return callback(new Error('No configuration for: ' + options.configuration));
+		pluginify.pluginifySteals(buildSteals, pluginifyOptions, function (error, str, steals) {
+			if (error) {
+				return callback(error);
 			}
 
-			// From the list of ids get all our Steals
-			buildSteals = utilities.getSteals(configuration.steals, ids);
-			pluginifyOptions = _.extend({
-				opener: configuration.steals.opener,
-				dev: options.dev
-			}, options.pluginify, info.pluginify, configuration.pluginify);
+			var banner = info.banner ? utilities.banner(info.banner, {
+				url: options.url || '',
+				info: info,
+				pkg: info,
+				ids: ids
+			}) : '';
+			var content = utilities.prettify(str, info.beautify);
 
-			pluginify.pluginifySteals(buildSteals, pluginifyOptions, function (error, str) {
-				if (error) {
-					return callback(error);
-				}
-
-				var banner = info.banner ? utilities.banner(info.banner, {
-					url: options.url || '',
-					info: info,
-					pkg: info,
-					ids: ids
-				}) : '';
-				var content = utilities.prettify(str, info.beautify);
-
-				callback(null, content, banner);
-			});
-		}
+			callback(null, content, banner, steals);
+		});
 	}
 }
 

--- a/lib/build/pluginify.js
+++ b/lib/build/pluginify.js
@@ -72,6 +72,7 @@ _.extend(pluginify, {
 		// Store steal shims (e.g. jQuery)
 		var stealShims = {};
 		var contents = [];
+		var visitedSteals = [];
 
 		_.each(options.shim, function(variable, id) {
 			nameMap[options.opener.id(id)] = variable;
@@ -90,6 +91,9 @@ _.extend(pluginify, {
 				var variableName = '__m' + index;
 				// Set the variable name for the current id
 				nameMap[id] = variableName;
+
+				// Add this to the list of visited Steals
+				visitedSteals.push(stl);
 
 				// When we come back from the recursive call all our dependencies are already
 				// parsed and have a name. Now create a list of all the variables names.
@@ -136,7 +140,7 @@ _.extend(pluginify, {
 		callback(null, _.template(options.wrapper, {
 			content: content,
 			exports: exportModules
-		}));
+		}), visitedSteals);
 	}
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 exports.load = require('./steal');
 exports.build = {
 	amdify: require('./build/amdify'),
-  stealify: require('./build/stealify'),
+	stealify: require('./build/stealify'),
 	open: require('./build/open'),
 	parse: require('./build/parse'),
 	pluginify: require('./build/pluginify'),

--- a/test/pluginify.js
+++ b/test/pluginify.js
@@ -25,7 +25,11 @@ describe('Pluginify', function() {
 					}
 				}
 			}
-		}, function(error, content) {
+		}, function(error, content, steals) {
+			// Make sure we got the expected Steals and in the right order
+			assert.deepEqual(steals.map(function(stl) {
+				return stl.options.id + ''
+			}), ['hello/mapped.js', 'hello/other.js',  'hello/hello.js']);
 			// Run the pluginified content
 			eval(content);
 			// And make sure that the exported object got updated


### PR DESCRIPTION
This option is not needed anymore as we will be handling this with excludes.
Also passes back the list of visited steals to the callback.
